### PR TITLE
implement CopyToAsync on read streams

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Managed/HttpContentReadStream.cs
@@ -59,7 +59,13 @@ namespace System.Net.Http.Managed
             return ReadAsync(buffer, offset, count, CancellationToken.None).Result;
         }
 
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            CopyToAsync(destination, bufferSize, CancellationToken.None).Wait();
+        }
+
         public abstract override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+        public abstract override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken);
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
This improves on base CopyToAsync behavior, and shows an improvement of ~3% on HttpClientPerf test using GET.

Also some small bits of cleanup/renaming.